### PR TITLE
Fix Dev Portal webhook registration links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cp .env.example .env
 
 ## Setting Up Payments
 
-Register a webhook in the [Alien Dev Portal](https://dev.alien.org/dashboard/webhooks) pointing to:
+Register a webhook in the [Alien Dev Portal](https://dev.alien.org/dashboard) pointing to:
 
 ```
 https://<your-website>/api/webhooks/payment
@@ -266,4 +266,4 @@ This app is designed to run on **Vercel**. Setup takes just a few clicks:
 
 Vercel auto-detects Next.js and handles the build. For auto-migrations on deploy, set `RUN_MIGRATIONS=true`.
 
-Once deployed, register your webhook in the [Alien Dev Portal](https://dev.alien.org/dashboard/webhooks) pointing to `https://<your-vercel-domain>/api/webhooks/payment`.
+Once deployed, register your webhook in the [Alien Dev Portal](https://dev.alien.org/dashboard) pointing to `https://<your-vercel-domain>/api/webhooks/payment`.


### PR DESCRIPTION
## Summary

Fixes two broken README links: webhook registration pointed at `dev.alien.org/dashboard/webhooks`, which no longer exists as a dedicated page — webhooks are now managed from the [Dev Portal dashboard](https://dev.alien.org/dashboard) (Payments tab). Both the "Setting Up Payments" section and the deployment checklist now link to the working page.

## Test plan

- [x] Verified the docs (`react-sdk/payments.md`) describe webhook management under the Dev Portal's Payments tab, matching the new link target
- [ ] Click-through of both links after merge

## Notes

- Docs-only change, no code touched. Follow-up to #8 (merged).

Co-Authored-By: Skrrt Bot <bot@skrrt.sh>
